### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,25 +41,25 @@ main() {
   # increment version number based on given release type
   case "$releaseType" in
   "major")
-    ((major++)); minor=0; build=0; pre="";;
+    ((++major)); minor=0; build=0; pre="";;
   "feature")
-    ((minor++)); build=0; pre="";;
+    ((++minor)); build=0; pre="";;
   "bug")
-    ((build++)); pre="";;
+    ((++build)); pre="";;
   "alpha")
-    ((preversion++))
+    ((++preversion))
     if [[ "$pre" != "-alpha" ]]; then
       preversion=1
     fi
     pre="-alpha$preversion";;
   "beta")
-    ((preversion++))
+    ((++preversion))
     if [[ "$pre" != "-beta" ]]; then
       preversion=1
     fi
     pre="-beta$preversion";;
   "rc")
-    ((preversion++))
+    ((++preversion))
     if [[ "$pre" != "-rc" ]]; then
       preversion=1
     fi


### PR DESCRIPTION
`entrypoint.sh` is failing for this case

```
/entrypoint.sh '0.5.0' 'bug'
```

The problem is described [here](https://unix.stackexchange.com/questions/146773/why-bash-increment-n-0n-return-error) and its basically that `((build++))` is using `build` before incrementing it (so value is 0) and value 0 is translated from bash as exit code 1 (which makes the script terminate since `set -x` is set).
