### PR TITLE
Fix alpha, beta and rc release bump on no preversion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: Increment Semantic Version
-description: Bump a given semantic version by a release type ( major | feature | bug | alpha | beta | rc ).
-author: Christian Dräger
+description: Bump a given semantic version by a release type ( major | minor | patch ) and add a possible postfix
+author: Martin Beentjes
 branding:
   icon: 'tag'
   color: 'purple'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Increment Semantic Version
-description: Bump a given semantic version by a release type ( major | minor | patch ) and add a possible postfix
+description: Bump a given semantic version by a release type ( major | minor | patch ) and add a possible postfix ( alpha | beta | rc )
 author: Christian Dräger
 branding:
   icon: 'tag'

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: Increment Semantic Version
 description: Bump a given semantic version by a release type ( major | minor | patch ) and add a possible postfix
-author: Christan Dräger
+author: Christian Dräger
 branding:
   icon: 'tag'
   color: 'purple'

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: Increment Semantic Version
 description: Bump a given semantic version by a release type ( major | minor | patch ) and add a possible postfix
-author: Martin Beentjes
+author: Christan Dräger
 branding:
   icon: 'tag'
   color: 'purple'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,16 +11,16 @@ set -euo pipefail
 
 main() {
 
-  prev_version="$1"; releaseType="$2"
+  prev_version="$1"; release_type="$2"
 
   if [[ "$prev_version" == "" ]]; then
     echo "could not read previous version"; exit 1
   fi
 
-  possibleReleaseTypes="major feature bug alpha beta rc"
+  possible_release_types="major feature bug alpha beta rc"
 
-  if [[ ! ${possibleReleaseTypes[*]} =~ ${releaseType} ]]; then
-    echo "valid argument: [ ${possibleReleaseTypes[*]} ]"; exit 1
+  if [[ ! ${possible_release_types[*]} =~ ${release_type} ]]; then
+    echo "valid argument: [ ${possible_release_types[*]} ]"; exit 1
   fi
 
   major=0; minor=0; patch=0; pre=""; preversion=0
@@ -39,7 +39,7 @@ main() {
   fi
 
   # increment version number based on given release type
-  case "$releaseType" in
+  case "$release_type" in
   "major")
     ((++major)); minor=0; patch=0; pre="";;
   "feature")
@@ -67,7 +67,7 @@ main() {
   esac
 
   next_version="${major}.${minor}.${patch}${pre}"
-  echo "create $releaseType-release version: $prev_version -> $next_version"
+  echo "create $release_type-release version: $prev_version -> $next_version"
 
   echo ::set-output name=next-version::"$next_version"
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,29 +23,29 @@ main() {
     echo "valid argument: [ ${possibleReleaseTypes[*]} ]"; exit 1
   fi
 
-  major=0; minor=0; build=0; pre=""; preversion=0
+  major=0; minor=0; patch=0; pre=""; preversion=0
 
   # break down the version number into it's components
   regex="^([0-9]+).([0-9]+).([0-9]+)((-[a-z]+)([0-9]+))?$"
   if [[ $prev_version =~ $regex ]]; then
     major="${BASH_REMATCH[1]}"
     minor="${BASH_REMATCH[2]}"
-    build="${BASH_REMATCH[3]}"
+    patch="${BASH_REMATCH[3]}"
     pre="${BASH_REMATCH[5]}"
     preversion="${BASH_REMATCH[6]}"
   else
-    echo "previous version '$prev_version' is not a symantic version"
+    echo "previous version '$prev_version' is not a semantic version"
     exit 1
   fi
 
   # increment version number based on given release type
   case "$releaseType" in
   "major")
-    ((++major)); minor=0; build=0; pre="";;
+    ((++major)); minor=0; patch=0; pre="";;
   "feature")
-    ((++minor)); build=0; pre="";;
+    ((++minor)); patch=0; pre="";;
   "bug")
-    ((++build)); pre="";;
+    ((++patch)); pre="";;
   "alpha")
     ((++preversion))
     if [[ "$pre" != "-alpha" ]]; then
@@ -66,7 +66,7 @@ main() {
     pre="-rc$preversion";;
   esac
 
-  next_version="${major}.${minor}.${build}${pre}"
+  next_version="${major}.${minor}.${patch}${pre}"
   echo "create $releaseType-release version: $prev_version -> $next_version"
 
   echo ::set-output name=next-version::"$next_version"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,18 +47,27 @@ main() {
   "bug")
     ((++patch)); pre="";;
   "alpha")
+    if [[ ! -z "$preversion" ]]; then
+      preversion=0
+    fi
     ((++preversion))
     if [[ "$pre" != "-alpha" ]]; then
       preversion=1
     fi
     pre="-alpha$preversion";;
   "beta")
+    if [[ ! -z "$preversion" ]]; then
+      preversion=0
+    fi
     ((++preversion))
     if [[ "$pre" != "-beta" ]]; then
       preversion=1
     fi
     pre="-beta$preversion";;
   "rc")
+    if [[ ! -z "$preversion" ]]; then
+      preversion=0
+    fi
     ((++preversion))
     if [[ "$pre" != "-rc" ]]; then
       preversion=1


### PR DESCRIPTION
This PR fixes #2 by checking null value of the `preversion` variable and if it is null it will set it to 0.