### PR TITLE
Fix incrementation of alpha, beta and rc `preversion` variable in cases if there are `pre` already.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,30 +47,39 @@ main() {
   "bug")
     ((++patch)); pre="";;
   "alpha")
-    if [[ ! -z "$preversion" ]]; then
-      preversion=0
-    fi
-    ((++preversion))
-    if [[ "$pre" != "-alpha" ]]; then
-      preversion=1
+    if [[ -z "$preversion" ]];
+      then
+        preversion=0
+      else
+        if [[ "$pre" != "-alpha" ]];
+          then
+          preversion=1
+          else ((++preversion))
+        fi
     fi
     pre="-alpha$preversion";;
   "beta")
-    if [[ ! -z "$preversion" ]]; then
-      preversion=0
-    fi
-    ((++preversion))
-    if [[ "$pre" != "-beta" ]]; then
-      preversion=1
+    if [[ -z "$preversion" ]];
+      then
+        preversion=0
+      else
+        if [[ "$pre" != "-beta" ]];
+          then
+          preversion=1
+          else ((++preversion))
+        fi
     fi
     pre="-beta$preversion";;
   "rc")
-    if [[ ! -z "$preversion" ]]; then
-      preversion=0
-    fi
-    ((++preversion))
-    if [[ "$pre" != "-rc" ]]; then
-      preversion=1
+    if [[ -z "$preversion" ]];
+      then
+        preversion=0
+      else
+        if [[ "$pre" != "-rc" ]];
+          then
+          preversion=1
+          else ((++preversion))
+        fi
     fi
     pre="-rc$preversion";;
   esac


### PR DESCRIPTION
This PR fixes issue #4 

Provides next logic:

1. IF there is no `$preversion`, THEN `preversion=0`
2. ELSE IF `pre != "-alpha"`, THEN `preversion=1` (same as before)
3. ELSE increment `preversion`

The same for `beta` and `rc`.

Here some tests results:
```
bash entrypoint.sh 1.15.0-beta1 alpha
create alpha-release version: 1.15.0-beta1 -> 1.15.0-alpha1
```
```
bash entrypoint.sh 1.15.0-beta1 beta
create beta-release version: 1.15.0-beta1 -> 1.15.0-beta2
```
```
bash entrypoint.sh 1.15.0-alpha22 alpha
create alpha-release version: 1.15.0-alpha22 -> 1.15.0-alpha23
```
```
bash entrypoint.sh 1.15.0 rc
create rc-release version: 1.15.0 -> 1.15.0-rc0
```
