### PR TITLE
Update for deprecating set-output commands

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,7 +87,7 @@ main() {
   next_version="${major}.${minor}.${patch}${pre}"
   echo "create $release_type-release version: $prev_version -> $next_version"
 
-  echo "'next-version'=$next_version" >> $GITHUB_OUTPUT
+  echo "next-version=$next_version" >> $GITHUB_OUTPUT
 }
 
 main "$1" "$2"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,7 +87,7 @@ main() {
   next_version="${major}.${minor}.${patch}${pre}"
   echo "create $release_type-release version: $prev_version -> $next_version"
 
-  echo ::set-output name=next-version::"$next_version"
+  echo "'next-version'=$next_version" >> $GITHUB_OUTPUT
 }
 
 main "$1" "$2"


### PR DESCRIPTION
set-output workflow commands will be deprecated on 31st May 2023.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR changes set-output commands to the new way to pass data using GITHUB_OUTPUT environment files.