### PR TITLE
Support a dot in pre release versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,23 +31,24 @@ The incremented version.
     - name: Do something with your bumped release version
       run: echo ${{ steps.bump_version.outputs.next-version }}
       # will print 2.12.0
-      
+
 ## input / output Examples
 
 | version-fragment | current-version |   | output        |
 | ---------------- | --------------- | - | ------------- |
 | major            | 2.11.7          |   | 3.0.0         |
-| major            | 2.11.7-alpha3   |   | 3.0.0         |
+| major            | 2.11.7-alpha.3   |   | 3.0.0         |
 | feature          | 2.11.7          |   | 2.12.0        |
-| feature          | 2.11.7-alpha3   |   | 2.12.0        |
+| feature          | 2.11.7-alpha.3   |   | 2.12.0        |
 | bug              | 2.11.7          |   | 2.11.8        |
-| bug              | 2.11.7-alpha3   |   | 2.11.8        |
-| alpha            | 2.11.7          |   | 2.11.7-alpha1 |
-| alpha            | 2.11.7-alpha3   |   | 2.11.7-alpha4 |
-| beta             | 2.11.7          |   | 2.11.7-beta1  |
-| beta             | 2.11.7-alpha3   |   | 2.11.7-beta1  |
-| rc               | 2.11.7          |   | 2.11.7-rc1    |
-| rc               | 2.11.7-alpha3   |   | 2.11.7-rc1    |
+| bug              | 2.11.7-alpha.3   |   | 2.11.8        |
+| alpha            | 2.11.7          |   | 2.11.7-alpha.1 |
+| alpha            | 2.11.7-alpha.3   |   | 2.11.7-alpha.4 |
+| beta             | 2.11.7          |   | 2.11.7-beta.1  |
+| beta             | 2.11.7-alpha.3   |   | 2.11.7-beta.1  |
+| rc               | 2.11.7          |   | 2.11.7-rc.1    |
+| rc               | 2.11.7-alpha.3   |   | 2.11.7-rc.1    |
 
 # License
+
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ main() {
   major=0; minor=0; patch=0; pre=""; preversion=0
 
   # break down the version number into it's components
-  regex="^([0-9]+).([0-9]+).([0-9]+)((-[a-z]+).?([0-9]+))?$"
+  regex="^v?([0-9]+).([0-9]+).([0-9]+)((-[a-z]+).?([0-9]+))?$"
   if [[ $prev_version =~ $regex ]]; then
     major="${BASH_REMATCH[1]}"
     minor="${BASH_REMATCH[2]}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ main() {
   major=0; minor=0; patch=0; pre=""; preversion=0
 
   # break down the version number into it's components
-  regex="^([0-9]+).([0-9]+).([0-9]+)((-[a-z]+)([0-9]+))?$"
+  regex="^([0-9]+).([0-9]+).([0-9]+)((-[a-z]+).?([0-9]+))?$"
   if [[ $prev_version =~ $regex ]]; then
     major="${BASH_REMATCH[1]}"
     minor="${BASH_REMATCH[2]}"
@@ -57,7 +57,7 @@ main() {
           else ((++preversion))
         fi
     fi
-    pre="-alpha$preversion";;
+    pre="-alpha.$preversion";;
   "beta")
     if [[ -z "$preversion" ]];
       then
@@ -69,7 +69,7 @@ main() {
           else ((++preversion))
         fi
     fi
-    pre="-beta$preversion";;
+    pre="-beta.$preversion";;
   "rc")
     if [[ -z "$preversion" ]];
       then
@@ -81,7 +81,7 @@ main() {
           else ((++preversion))
         fi
     fi
-    pre="-rc$preversion";;
+    pre="-rc.$preversion";;
   esac
 
   next_version="${major}.${minor}.${patch}${pre}"


### PR DESCRIPTION
Many people use a dot in pre release versions, like so `1.2.3-beta.1`, so this PR looks to add support for that format and possibly support for version templates.

### TODO:
- [x] Add basic support for a dot a in pre release versions
- [X] Support a `v` in front of the current version 
- [ ] Add support to version templates inputs, such as 
  ```yaml
  with:
    versionTemplate: v{{ major }}.{{ minor }}.{{ patch }}{{ preReleaseTag }}
    preReleaseTagTemplate: -{{ stage }}.{{ preVersion }}
  ```
