### PR TITLE
Mitigate script injection attack

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ runs:
   steps:
     - name: Run entrypoint.sh
       id: bump-version
+      env:
+        CURRENT_VERSION: "${{ inputs.current-version }}"
+        VERSION_FRAGMENT: "${{ inputs.version-fragment }}"
       shell: bash
       run: |
-        "$GITHUB_ACTION_PATH"/entrypoint.sh "${{ inputs.current-version }}" "${{ inputs.version-fragment }}"
+        "$GITHUB_ACTION_PATH"/entrypoint.sh "${CURRENT_VERSION}" "${VERSION_FRAGMENT}"


### PR DESCRIPTION
It is possible to perform script injection via inputs. This fix mitigates it. More details [here](https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).